### PR TITLE
Refactor MainAgent and services

### DIFF
--- a/src/talos/core/cli.py
+++ b/src/talos/core/cli.py
@@ -4,7 +4,6 @@ from langchain_openai import ChatOpenAI
 from pydantic.types import SecretStr
 
 from talos.core.main_agent import MainAgent
-from talos.services.proposals.models import RunParams
 
 
 def main() -> None:
@@ -27,7 +26,7 @@ def main() -> None:
         if query.lower() == "exit":
             break
 
-        response = agent.run(query, **RunParams().model_dump())
+        response = agent.run(query)
         print(response)
 
 

--- a/src/talos/services/abstract/github.py
+++ b/src/talos/services/abstract/github.py
@@ -9,7 +9,7 @@ class GitHub(Service, ABC):
     An abstract base class for a GitHub discipline.
     """
 
-    def __init__(self, llm: BaseLanguageModel, token: str):
+    def __init__(self, llm: BaseLanguageModel, token: str | None):
         self.llm = llm
         self.token = token
 

--- a/src/talos/services/models.py
+++ b/src/talos/services/models.py
@@ -15,6 +15,15 @@ class TicketStatus(str, Enum):
     CANCELLED = "CANCELLED"
 
 
+class TicketCreationRequest(BaseModel):
+    """
+    A request to create a ticket.
+    """
+
+    tool: str
+    tool_args: dict[str, Any]
+
+
 class Ticket(BaseModel):
     """
     A ticket for a long-running process.
@@ -24,15 +33,7 @@ class Ticket(BaseModel):
     status: TicketStatus = Field(..., description="The status of the ticket.")
     created_at: str = Field(..., description="The timestamp when the ticket was created.")
     updated_at: str = Field(..., description="The timestamp when the ticket was last updated.")
-
-
-class TicketCreationRequest(BaseModel):
-    """
-    A request to create a ticket.
-    """
-
-    tool: str
-    tool_args: dict[str, Any]
+    request: TicketCreationRequest = Field(..., description="The request that created the ticket.")
 
 
 class TicketResult(BaseModel):


### PR DESCRIPTION
This commit refactors the `MainAgent` to be a regular agent and moves the service routing logic to a tool. It also creates a generic `create_ticket` tool for each service and a `get_ticket_status` tool.

The services have been updated to handle missing API keys gracefully. Instead of erroring on initialization, the service's tool will respond with an error message when queried.

The CLI has been updated to interact with the `MainAgent` as a regular agent.