### PR TITLE
feat: Allow prompt to be updated at each step

### DIFF
--- a/src/talos/core/agent.py
+++ b/src/talos/core/agent.py
@@ -59,6 +59,8 @@ class Agent(BaseModel):
         if history:
             self.history.extend(history)
 
+        self.prompt_manager.update_prompt_template(self.history)
+
         message_with_context = self._add_context(message, **kwargs)
         self.history.append(HumanMessage(content=message_with_context))
 

--- a/src/talos/prompts/prompt_manager.py
+++ b/src/talos/prompts/prompt_manager.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from talos.prompts.prompt import Prompt
+from langchain_core.messages import BaseMessage
 
 
 class PromptManager(ABC):
@@ -11,5 +12,11 @@ class PromptManager(ABC):
     def get_prompt(self, name: str) -> Prompt | None:
         """
         Gets a prompt by name.
+        """
+        pass
+
+    def update_prompt_template(self, history: list[BaseMessage]):
+        """
+        Updates the prompt template based on the conversation history.
         """
         pass


### PR DESCRIPTION
This commit modifies the `Agent` and `PromptManager` classes to allow the prompt to be updated at each step of the conversation.

The `Agent` class now calls a new `update_prompt_template` method on the `PromptManager` before running the chain.

The `PromptManager` class has a new abstract method `update_prompt_template` that can be implemented by subclasses to update the prompt based on the conversation history.