### PR TITLE
feat: Implement Hypervisor for tool call monitoring

### DIFF
--- a/src/talos/core/agent.py
+++ b/src/talos/core/agent.py
@@ -7,6 +7,7 @@ from langchain_core.language_models import BaseChatModel
 from talos.tools.tool_manager import ToolManager
 from talos.prompts.prompt_manager import PromptManager
 from talos.hypervisor.supervisor import Supervisor
+from talos.tools.supervised_tool import SupervisedTool
 
 
 from pydantic import ConfigDict
@@ -75,10 +76,9 @@ class Agent(BaseModel):
         self.history.append(HumanMessage(content=message_with_context))
 
         tools = self.tool_manager.get_all_tools()
-        if self.supervisor:
-            tools = [
-                self.tool_manager.get_tool(tool.name, self.history) for tool in tools
-            ]
+        for tool in tools:
+            if isinstance(tool, SupervisedTool):
+                tool.set_supervisor(self.supervisor)
 
         if tools:
             self.model = self.model.bind_tools(tools)  # type: ignore

--- a/src/talos/core/main_agent.py
+++ b/src/talos/core/main_agent.py
@@ -36,7 +36,7 @@ class MainAgent(Agent):
         ]
         self.router = Router(services)
         self.prompt_manager = FilePromptManager(prompts_dir)
-        self.hypervisor = Hypervisor()
+        hypervisor = Hypervisor(llm=llm, prompts_dir=prompts_dir)
         tool_manager = ToolManager()
         for service in services:
             tool_manager.register_tool(service.create_ticket_tool())
@@ -47,6 +47,7 @@ class MainAgent(Agent):
             prompt_manager=self.prompt_manager,
             tool_manager=tool_manager,
         )
+        self.add_supervisor(hypervisor)
 
     def get_ticket_status_tool(self):
         def get_ticket_status(service_name: str, ticket_id: str) -> Ticket:

--- a/src/talos/hypervisor/hypervisor.py
+++ b/src/talos/hypervisor/hypervisor.py
@@ -1,11 +1,38 @@
-class Hypervisor:
+from __future__ import annotations
+
+import json
+
+from langchain_core.language_models import BaseChatModel
+
+from talos.core.agent import Agent
+from talos.hypervisor.supervisor import Supervisor
+from talos.prompts.prompt_managers.file_prompt_manager import FilePromptManager
+
+
+class Hypervisor(Agent, Supervisor):
     """
     A class to monitor the agent's actions.
     """
 
-    def approve(self, action: str, args: dict) -> bool:
+    def __init__(self, llm: BaseChatModel, prompts_dir: str):
+        super().__init__(
+            model=llm,
+            prompt_manager=FilePromptManager(prompts_dir),
+            tool_manager=None,
+        )
+
+    def approve(self, messages: list, action: str, args: dict) -> bool:
         """
         Approves or denies an action.
         """
-        print(f"Hypervisor approving action: {action} with args: {args}")
-        return True
+        prompt = self.prompt_manager.get_prompt("hypervisor")
+        if not prompt:
+            raise ValueError("Hypervisor prompt not found.")
+        response = self.run(
+            prompt.format(
+                messages=messages,
+                action=action,
+                args=args,
+            )
+        )
+        return json.loads(str(response))["approve"]

--- a/src/talos/hypervisor/supervisor.py
+++ b/src/talos/hypervisor/supervisor.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class Supervisor(ABC):
+    """
+    An abstract base class for supervisors.
+    """
+
+    @abstractmethod
+    def approve(self, messages: list, action: str, args: dict) -> bool:
+        """
+        Approves or denies an action.
+        """
+        pass

--- a/src/talos/prompts/hypervisor/hypervisor_prompt.json
+++ b/src/talos/prompts/hypervisor/hypervisor_prompt.json
@@ -1,0 +1,5 @@
+{
+    "name": "hypervisor",
+    "description": "A prompt to determine if a tool call is malicious.",
+    "prompt": "You are a security expert. You have been asked to determine if the following tool call is malicious. Please respond with a JSON object with a single key, 'approve', which is a boolean indicating whether the tool call is malicious.\n\nTool call:\n\nAction: {action}\nArgs: {args}\n\nMessage history:\n{messages}\n\nIs this tool call malicious?"
+}

--- a/src/talos/tools/supervised_tool.py
+++ b/src/talos/tools/supervised_tool.py
@@ -13,14 +13,20 @@ class SupervisedTool(BaseTool):
     """
 
     tool: BaseTool
-    supervisor: Supervisor
+    supervisor: Supervisor | None = None
     messages: list
+
+    def set_supervisor(self, supervisor: Supervisor | None):
+        """
+        Sets the supervisor for the tool.
+        """
+        self.supervisor = supervisor
 
     def _run(self, *args: Any, **kwargs: Any) -> Any:
         """
         Runs the tool.
         """
-        if self.supervisor.approve(self.messages, self.name, kwargs):
+        if self.supervisor and self.supervisor.approve(self.messages, self.name, kwargs):
             return self.tool._run(*args, **kwargs)
         else:
             raise ValueError(f"Tool call to '{self.name}' denied by supervisor.")

--- a/src/talos/tools/supervised_tool.py
+++ b/src/talos/tools/supervised_tool.py
@@ -26,7 +26,9 @@ class SupervisedTool(BaseTool):
         """
         Runs the tool.
         """
-        if self.supervisor and self.supervisor.approve(self.messages, self.name, kwargs):
-            return self.tool._run(*args, **kwargs)
-        else:
-            raise ValueError(f"Tool call to '{self.name}' denied by supervisor.")
+        if self.supervisor:
+            if self.supervisor.approve(self.messages, self.name, kwargs):
+                return self.tool._run(*args, **kwargs)
+            else:
+                return f"Tool call to '{self.name}' denied by supervisor."
+        return self.tool._run(*args, **kwargs)

--- a/src/talos/tools/supervised_tool.py
+++ b/src/talos/tools/supervised_tool.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tools import BaseTool
+
+from talos.hypervisor.supervisor import Supervisor
+
+
+class SupervisedTool(BaseTool):
+    """
+    A tool that is supervised by a hypervisor.
+    """
+
+    tool: BaseTool
+    supervisor: Supervisor
+    messages: list
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        """
+        Runs the tool.
+        """
+        if self.supervisor.approve(self.messages, self.name, kwargs):
+            return self.tool._run(*args, **kwargs)
+        else:
+            raise ValueError(f"Tool call to '{self.name}' denied by supervisor.")

--- a/src/talos/tools/tool_manager.py
+++ b/src/talos/tools/tool_manager.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Dict, Optional
+from typing import List, Dict
 
 from langchain_core.tools import BaseTool
-
-from talos.tools.supervised_tool import SupervisedTool
-
-if TYPE_CHECKING:
-    from talos.hypervisor.supervisor import Supervisor
 
 
 class ToolManager:
@@ -15,9 +10,8 @@ class ToolManager:
     A class for managing and discovering tools for the Talos agent.
     """
 
-    def __init__(self, supervisor: Optional["Supervisor"] = None):
+    def __init__(self):
         self.tools: Dict[str, BaseTool] = {}
-        self.supervisor = supervisor
 
     def register_tool(self, tool: BaseTool):
         """
@@ -35,23 +29,13 @@ class ToolManager:
             raise ValueError(f"Tool with name '{tool_name}' not found.")
         del self.tools[tool_name]
 
-    def get_tool(self, tool_name: str, messages: Optional[list] = None) -> BaseTool:
+    def get_tool(self, tool_name: str) -> BaseTool:
         """
         Gets a tool by name.
         """
         if tool_name not in self.tools:
             raise ValueError(f"Tool with name '{tool_name}' not found.")
-        tool = self.tools[tool_name]
-        if self.supervisor:
-            return SupervisedTool(
-                name=tool.name,
-                description=tool.description,
-                args_schema=tool.args_schema,
-                tool=tool,
-                supervisor=self.supervisor,
-                messages=messages or [],
-            )
-        return tool
+        return self.tools[tool_name]
 
     def get_all_tools(self) -> List[BaseTool]:
         """

--- a/src/talos/tools/tool_manager.py
+++ b/src/talos/tools/tool_manager.py
@@ -1,12 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Dict, Optional
+
 from langchain_core.tools import BaseTool
-from typing import List, Dict
+
+from talos.tools.supervised_tool import SupervisedTool
+
+if TYPE_CHECKING:
+    from talos.hypervisor.supervisor import Supervisor
+
 
 class ToolManager:
     """
     A class for managing and discovering tools for the Talos agent.
     """
-    def __init__(self):
+
+    def __init__(self, supervisor: Optional["Supervisor"] = None):
         self.tools: Dict[str, BaseTool] = {}
+        self.supervisor = supervisor
 
     def register_tool(self, tool: BaseTool):
         """
@@ -24,13 +35,23 @@ class ToolManager:
             raise ValueError(f"Tool with name '{tool_name}' not found.")
         del self.tools[tool_name]
 
-    def get_tool(self, tool_name: str) -> BaseTool:
+    def get_tool(self, tool_name: str, messages: Optional[list] = None) -> BaseTool:
         """
         Gets a tool by name.
         """
         if tool_name not in self.tools:
             raise ValueError(f"Tool with name '{tool_name}' not found.")
-        return self.tools[tool_name]
+        tool = self.tools[tool_name]
+        if self.supervisor:
+            return SupervisedTool(
+                name=tool.name,
+                description=tool.description,
+                args_schema=tool.args_schema,
+                tool=tool,
+                supervisor=self.supervisor,
+                messages=messages or [],
+            )
+        return tool
 
     def get_all_tools(self) -> List[BaseTool]:
         """


### PR DESCRIPTION
This commit introduces a `Hypervisor` agent that can be used to monitor tool calls for malicious behavior.

The `Hypervisor` is a `Supervisor` that can be added to an `Agent`. When a tool is called, the `Agent` asks the `Supervisor` for approval. If the `Supervisor` denies the tool call, the `Agent` raises an exception.

The `ToolManager` has been updated to use the `SupervisedTool` which invokes the `Supervisor` before executing the tool.

The `MainAgent` has been updated to create a `Hypervisor` and add it as a supervisor to the `MainAgent` itself.