### PR TITLE
Fix: Update prompt template in my run method

### DIFF
--- a/src/talos/core/agent.py
+++ b/src/talos/core/agent.py
@@ -71,6 +71,7 @@ class Agent(BaseModel):
             self.history.extend(history)
 
         self.prompt_manager.update_prompt_template(self.history)
+        self.set_prompt()
 
         message_with_context = self._add_context(message, **kwargs)
         self.history.append(HumanMessage(content=message_with_context))


### PR DESCRIPTION
My prompt template was not being updated correctly in my `run` method. This change ensures that the prompt template is refreshed from the PromptManager on every run, so that I always use the latest prompt.