### PR TITLE
feat(hypervisor): Allow Hypervisor to use Agent's message history

### DIFF
--- a/src/talos/core/agent.py
+++ b/src/talos/core/agent.py
@@ -46,8 +46,7 @@ class Agent(BaseModel):
         Adds a supervisor to the agent.
         """
         self.supervisor = supervisor
-        if hasattr(supervisor, "set_agent"):
-            supervisor.set_agent(self)
+        supervisor.set_agent(self)
 
     def add_to_history(self, messages: list[BaseMessage]):
         """

--- a/src/talos/core/agent.py
+++ b/src/talos/core/agent.py
@@ -46,6 +46,8 @@ class Agent(BaseModel):
         Adds a supervisor to the agent.
         """
         self.supervisor = supervisor
+        if hasattr(supervisor, "set_agent"):
+            supervisor.set_agent(self)
 
     def add_to_history(self, messages: list[BaseMessage]):
         """

--- a/src/talos/hypervisor/hypervisor.py
+++ b/src/talos/hypervisor/hypervisor.py
@@ -18,15 +18,23 @@ class Hypervisor(Agent, Supervisor):
     """
 
     prompts_dir: str
+    agent: Agent | None = None
 
     def model_post_init(self, __context: Any) -> None:
         self.prompt_manager = FilePromptManager(self.prompts_dir)
         self.tool_manager = ToolManager()
 
+    def set_agent(self, agent: Agent):
+        """
+        Sets the agent to be supervised.
+        """
+        self.agent = agent
+
     def approve(self, messages: list, action: str, args: dict) -> bool:
         """
         Approves or denies an action.
         """
+        agent_history = self.agent.history if self.agent else []
         prompt = self.prompt_manager.get_prompt("hypervisor")
         if not prompt:
             raise ValueError("Hypervisor prompt not found.")
@@ -35,6 +43,7 @@ class Hypervisor(Agent, Supervisor):
                 messages=messages,
                 action=action,
                 args=args,
+                agent_history=agent_history,
             )
         )
         return json.loads(str(response))["approve"]

--- a/src/talos/hypervisor/supervisor.py
+++ b/src/talos/hypervisor/supervisor.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from talos.core.agent import Agent
 
 
 class Supervisor(ABC):
     """
     An abstract base class for supervisors.
     """
+
+    @abstractmethod
+    def set_agent(self, agent: "Agent"):
+        """
+        Sets the agent to be supervised.
+        """
+        pass
 
     @abstractmethod
     def approve(self, messages: list, action: str, args: dict) -> bool:


### PR DESCRIPTION
This commit introduces the following changes:

- The `Hypervisor` class can now take a reference to an `Agent` and use that agent's message history in its determination.
- A `set_agent` method has been added to the `Hypervisor` class to set the agent to be supervised.
- The `approve` method in the `Hypervisor` has been updated to include my message history in the prompt.
- The `add_supervisor` method in the `Agent` class now calls the supervisor's `set_agent` method.