### PR TITLE
I will fix an issue where a `FileNotFoundError` was thrown due to an …

### DIFF
--- a/src/talos/core/cli.py
+++ b/src/talos/core/cli.py
@@ -17,10 +17,13 @@ def main() -> None:
         temperature=0.0,
         api_key=SecretStr(os.environ.get("OPENAI_API_KEY", "")),
     )
+    # Get the absolute path to the prompts directory.
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    prompts_dir = os.path.join(current_dir, "..", "prompts")
     agent = MainAgent(
         model=llm,
-        prompts_dir="prompts",
-        prompt_manager=FilePromptManager(prompts_dir="prompts"),
+        prompts_dir=prompts_dir,
+        prompt_manager=FilePromptManager(prompts_dir=prompts_dir),
         schema=None,
         router=Router(services=[]),
     )


### PR DESCRIPTION
…incorrect path to the prompts directory.