### PR TITLE
I've addressed an error that was occurring when the MainAgent was bei…

### DIFF
--- a/src/talos/core/agent.py
+++ b/src/talos/core/agent.py
@@ -35,9 +35,10 @@ class Agent(BaseModel):
     history: list[BaseMessage] = []
 
     def model_post_init(self, __context: Any) -> None:
-        self.set_prompt()
+        # We don't set a prompt by default. It is up to the agent to set its own prompt.
+        pass
 
-    def set_prompt(self, name: str = "default"):
+    def set_prompt(self, name: str):
         prompt = self.prompt_manager.get_prompt(name)
         if not prompt:
             raise ValueError(f"The prompt '{name}' is not defined.")

--- a/src/talos/core/agent.py
+++ b/src/talos/core/agent.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -33,10 +33,6 @@ class Agent(BaseModel):
 
     _prompt_template: ChatPromptTemplate = PrivateAttr()
     history: list[BaseMessage] = []
-
-    def model_post_init(self, __context: Any) -> None:
-        # We don't set a prompt by default. It is up to the agent to set its own prompt.
-        pass
 
     def set_prompt(self, name: str):
         prompt = self.prompt_manager.get_prompt(name)

--- a/src/talos/core/main_agent.py
+++ b/src/talos/core/main_agent.py
@@ -29,6 +29,7 @@ class MainAgent(Agent):
 
     def model_post_init(self, __context: Any) -> None:
         super().model_post_init(__context)
+        self.prompt_manager = FilePromptManager(self.prompts_dir)
         self.set_prompt("main_agent_prompt")
         services: list[Service] = [
             ProposalsService(llm=self.model),
@@ -36,7 +37,6 @@ class MainAgent(Agent):
             GitHubService(llm=self.model, token=os.environ.get("GITHUB_TOKEN")),
         ]
         self.router = Router(services)
-        self.prompt_manager = FilePromptManager(self.prompts_dir)
         hypervisor = Hypervisor(
             model=self.model, prompts_dir=self.prompts_dir, prompt_manager=self.prompt_manager, schema=None
         )

--- a/src/talos/prompts/default_prompt.json
+++ b/src/talos/prompts/default_prompt.json
@@ -1,0 +1,5 @@
+{
+    "name": "default",
+    "template": "{messages}",
+    "input_variables": ["messages"]
+}

--- a/src/talos/services/abstract/proposal_agent.py
+++ b/src/talos/services/abstract/proposal_agent.py
@@ -11,6 +11,7 @@ class ProposalAgent(Service):
     """
 
     def __init__(self, rag_dataset: Any, tools: list[Any]):
+        super().__init__()
         self.rag_dataset = rag_dataset
         self.tools = tools
 

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -7,6 +7,7 @@ from langchain_core.language_models import BaseChatModel
 
 from talos.core.main_agent import MainAgent
 from talos.core.router import Router
+from talos.hypervisor.hypervisor import Hypervisor
 from talos.prompts.prompt import Prompt
 from talos.prompts.prompt_managers.file_prompt_manager import FilePromptManager
 
@@ -16,23 +17,22 @@ def mock_model() -> BaseChatModel:
     return MagicMock(spec=BaseChatModel)
 
 
-@pytest.fixture
-def mock_prompt_manager() -> FilePromptManager:
-    mock = MagicMock(spec=FilePromptManager)
-    mock.get_prompt.return_value = Prompt(
-        name="main_agent_prompt",
-        template="You are a helpful assistant.",
-        input_variables=[],
-    )
-    return mock
-
-
-def test_main_agent_initialization(mock_model: BaseChatModel, mock_prompt_manager: FilePromptManager) -> None:
+def test_main_agent_initialization(mock_model: BaseChatModel) -> None:
     """
     Tests that the MainAgent can be initialized without errors.
     """
-    with patch("talos.prompts.prompt_managers.file_prompt_manager.FilePromptManager.load_prompts") as mock_load_prompts:
-        mock_load_prompts.return_value = None
+    with (
+        patch("talos.core.main_agent.FilePromptManager") as mock_file_prompt_manager,
+        patch("talos.core.main_agent.Hypervisor") as mock_hypervisor,
+    ):
+        mock_prompt_manager = MagicMock(spec=FilePromptManager)
+        mock_prompt_manager.get_prompt.return_value = Prompt(
+            name="main_agent_prompt",
+            template="You are a helpful assistant.",
+            input_variables=[],
+        )
+        mock_file_prompt_manager.return_value = mock_prompt_manager
+        mock_hypervisor.return_value = MagicMock(spec=Hypervisor)
         agent = MainAgent(
             model=mock_model,
             prompts_dir="",


### PR DESCRIPTION
…ng initialized. It was attempting to load a 'default' prompt that hadn't been set up.

Here's how I fixed it:

1. I created a `default_prompt.json` file.
2. I removed the default prompt setting from the `Agent` class.
3. I made sure to explicitly set the prompt in the `MainAgent` class.
4. I adjusted the tests to correctly handle the `FilePromptManager` and `Hypervisor` classes.