### PR TITLE
Refactor Services to Inherit from BaseModel

### DIFF
--- a/src/talos/services/abstract/github.py
+++ b/src/talos/services/abstract/github.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import Any
 
 from langchain_core.language_models import BaseLanguageModel
 
@@ -10,9 +13,11 @@ class GitHub(Service, ABC):
     An abstract base class for a GitHub discipline.
     """
 
-    def __init__(self, llm: BaseLanguageModel, token: str | None):
-        self.llm = llm
-        self.token = token
+    llm: BaseLanguageModel
+    token: str | None = None
+
+    def model_post_init(self, __context: Any) -> None:
+        super().model_post_init(__context)
 
     @abstractmethod
     def reply_to_issues(self, user: str, project: str) -> None:

--- a/src/talos/services/abstract/proposal_agent.py
+++ b/src/talos/services/abstract/proposal_agent.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import Any
 
@@ -10,10 +12,11 @@ class ProposalAgent(Service):
     An abstract base class for an agent that can evaluate proposals.
     """
 
-    def __init__(self, rag_dataset: Any, tools: list[Any]):
-        super().__init__()
-        self.rag_dataset = rag_dataset
-        self.tools = tools
+    rag_dataset: Any | None = None
+    tools: list[Any] | None = None
+
+    def model_post_init(self, __context: Any) -> None:
+        super().model_post_init(__context)
 
     @property
     def name(self) -> str:

--- a/src/talos/services/base.py
+++ b/src/talos/services/base.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
 import threading
 import time
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from langchain_core.tools import tool
+from pydantic import BaseModel, PrivateAttr
 
 from talos.services.models import Ticket, TicketCreationRequest, TicketResult, TicketStatus
 
 
-class Service(ABC):
+class Service(BaseModel, ABC):
     """
     An abstract base class for a service.
     Services are a way to organize and manage the agent's actions.
@@ -18,10 +21,12 @@ class Service(ABC):
     than traditional tools.
     """
 
-    def __init__(self) -> None:
-        self.tickets: Dict[str, Ticket] = {}
-        self.results: Dict[str, TicketResult] = {}
-        self.threads: Dict[str, threading.Thread] = {}
+    _tickets: Dict[str, Ticket] = PrivateAttr(default_factory=dict)
+    _results: Dict[str, TicketResult] = PrivateAttr(default_factory=dict)
+    _threads: Dict[str, threading.Thread] = PrivateAttr(default_factory=dict)
+
+    def model_post_init(self, __context: Any) -> None:
+        pass
 
     @property
     @abstractmethod
@@ -59,9 +64,9 @@ class Service(ABC):
                 updated_at=str(time.time()),
                 request=request,
             )
-            self.tickets[ticket_id] = ticket
+            self._tickets[ticket_id] = ticket
             thread = threading.Thread(target=self._run_in_background, args=(ticket_id, request.tool_args))
-            self.threads[ticket_id] = thread
+            self._threads[ticket_id] = thread
             thread.start()
             return ticket
 
@@ -71,61 +76,61 @@ class Service(ABC):
         """
         Runs the service in the background.
         """
-        self.tickets[ticket_id].status = TicketStatus.RUNNING
-        self.tickets[ticket_id].updated_at = str(time.time())
+        self._tickets[ticket_id].status = TicketStatus.RUNNING
+        self._tickets[ticket_id].updated_at = str(time.time())
         try:
             result = self.run(**tool_args)
-            self.results[ticket_id] = TicketResult(
+            self._results[ticket_id] = TicketResult(
                 ticket_id=ticket_id,
                 status=TicketStatus.COMPLETED,
                 result=result,
                 error=None,
             )
-            self.tickets[ticket_id].status = TicketStatus.COMPLETED
+            self._tickets[ticket_id].status = TicketStatus.COMPLETED
         except Exception as e:
-            self.results[ticket_id] = TicketResult(
+            self._results[ticket_id] = TicketResult(
                 ticket_id=ticket_id,
                 status=TicketStatus.FAILED,
                 result=None,
                 error=str(e),
             )
-            self.tickets[ticket_id].status = TicketStatus.FAILED
+            self._tickets[ticket_id].status = TicketStatus.FAILED
         finally:
-            self.tickets[ticket_id].updated_at = str(time.time())
+            self._tickets[ticket_id].updated_at = str(time.time())
 
-    def get_ticket_status(self, ticket_id: str) -> Optional[Ticket]:
+    def get_ticket_status(self, ticket_id: str) -> Ticket | None:
         """
         Checks on the status of a ticket number with the service.
         """
-        return self.tickets.get(ticket_id)
+        return self._tickets.get(ticket_id)
 
-    def cancel_ticket(self, ticket_id: str) -> Optional[Ticket]:
+    def cancel_ticket(self, ticket_id: str) -> Ticket | None:
         """
         Cancels the execution of a ticket number.
         """
-        if ticket_id in self.threads:
+        if ticket_id in self._threads:
             # Note: This is a simplistic way to "cancel" a thread.
             # It doesn't actually stop the thread, but it does prevent
             # the result from being stored.
-            self.threads[ticket_id].join(timeout=0.1)
-            if self.threads[ticket_id].is_alive():
+            self._threads[ticket_id].join(timeout=0.1)
+            if self._threads[ticket_id].is_alive():
                 # If the thread is still alive, we can't do much more
                 # to stop it without more complex mechanisms.
                 pass
-            del self.threads[ticket_id]
-            self.tickets[ticket_id].status = TicketStatus.CANCELLED
-            self.tickets[ticket_id].updated_at = str(time.time())
-            return self.tickets[ticket_id]
+            del self._threads[ticket_id]
+            self._tickets[ticket_id].status = TicketStatus.CANCELLED
+            self._tickets[ticket_id].updated_at = str(time.time())
+            return self._tickets[ticket_id]
         return None
 
-    def get_ticket_result(self, ticket_id: str) -> Optional[TicketResult]:
+    def get_ticket_result(self, ticket_id: str) -> TicketResult | None:
         """
         If it is finalized, to get the result of the execution.
         """
-        return self.results.get(ticket_id)
+        return self._results.get(ticket_id)
 
     def get_all_tickets(self) -> list[Ticket]:
         """
         Returns all tickets for this service.
         """
-        return list(self.tickets.values())
+        return list(self._tickets.values())

--- a/src/talos/services/implementations/github.py
+++ b/src/talos/services/implementations/github.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from typing import Any
 
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
-from langchain_core.language_models import BaseLanguageModel
+from pydantic import ConfigDict
 
 from talos.services.abstract.github import GitHub
 from talos.services.proposals.models import QueryResponse
@@ -14,15 +16,13 @@ class GitHubService(GitHub):
     A discipline for interacting with GitHub using PyGithub.
     """
 
-    def __init__(self, llm: BaseLanguageModel, token: str | None):
-        super().__init__(llm, token or "")
-        self.tools: GithubTools | None
-        if token:
-            self.tools = GithubTools(token)
-        else:
-            self.tools = None
-        self.llm = llm
-        self.token: str | None = token
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    tools: GithubTools | None = None
+
+    def model_post_init(self, __context: Any) -> None:
+        super().model_post_init(__context)
+        if self.token:
+            self.tools = GithubTools(self.token)
 
     @property
     def name(self) -> str:

--- a/src/talos/services/implementations/proposals.py
+++ b/src/talos/services/implementations/proposals.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from langchain.chains import LLMChain
@@ -13,14 +15,12 @@ class ProposalsService(ProposalAgent):
     A LangChain-based agent for evaluating proposals.
     """
 
-    def __init__(
-        self,
-        llm: BaseLanguageModel,
-        rag_dataset: Any = None,
-        tools: list[Any] | None = None,
-    ):
-        super().__init__(rag_dataset, tools if tools is not None else [])
-        self.llm = llm
+    llm: BaseLanguageModel
+    rag_dataset: Any | None = None
+    tools: list[Any] | None = None
+
+    def model_post_init(self, __context: Any) -> None:
+        super().model_post_init(__context)
 
     def run(self, **kwargs: Any) -> QueryResponse:
         if "proposal" in kwargs and "feedback" in kwargs:


### PR DESCRIPTION
This commit refactors the `Service` class and all of its subclasses to inherit from `pydantic.BaseModel`. This ensures that all services are properly initialized as Pydantic models, which prevents runtime errors related to attribute access.

The following changes were made:

- The `Service` class now inherits from `pydantic.BaseModel` and `abc.ABC`.
- The `__init__` methods of all services have been replaced with `model_post_init`.
- `arbitrary_types_allowed` has been enabled for `GitHubService` to allow the use of `GithubTools` as a type hint.