### PR TITLE
feat: Add SupervisedTool example

### DIFF
--- a/src/talos/tools/__init__.py
+++ b/src/talos/tools/__init__.py
@@ -1,0 +1,3 @@
+from .tool_example import SimpleSupervisor, get_current_time
+
+__all__ = ["get_current_time", "SimpleSupervisor"]

--- a/src/talos/tools/supervised_tool.py
+++ b/src/talos/tools/supervised_tool.py
@@ -26,9 +26,10 @@ class SupervisedTool(BaseTool):
         """
         Runs the tool.
         """
+        tool_input = args[0] if args else {}
         if self.supervisor:
             if self.supervisor.approve(self.messages, self.name, kwargs):
-                return self.tool._run(*args, **kwargs)
+                return self.tool.run(tool_input, **kwargs)
             else:
                 return f"Tool call to '{self.name}' denied by supervisor."
-        return self.tool._run(*args, **kwargs)
+        return self.tool.run(tool_input, **kwargs)

--- a/src/talos/tools/tool_example.py
+++ b/src/talos/tools/tool_example.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.tools import tool
+
+from talos.hypervisor.supervisor import Supervisor
+
+if TYPE_CHECKING:
+    from talos.core.agent import Agent
+
+
+@tool
+def get_current_time() -> str:
+    """
+    Returns the current time.
+    """
+    return datetime.datetime.now().isoformat()
+
+
+class SimpleSupervisor(Supervisor):
+    """
+    A simple supervisor that approves every other tool call.
+    """
+
+    def __init__(self):
+        self.counter = 0
+
+    def set_agent(self, agent: "Agent"):
+        """
+        Sets the agent to be supervised.
+        """
+        pass
+
+    def approve(self, messages: list, action: str, args: dict[str, Any]) -> bool:
+        """
+        Approves or denies an action.
+        """
+        self.counter += 1
+        return self.counter % 2 != 0

--- a/tool_example.py
+++ b/tool_example.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from talos.tools import SimpleSupervisor, get_current_time
+from talos.tools.supervised_tool import SupervisedTool
+
+
+def main():
+    """
+    An example of how to use the SupervisedTool.
+    """
+    # Create a supervisor
+    supervisor = SimpleSupervisor()
+
+    # Create a tool
+    tool = get_current_time
+    print(f"Tool: {tool.name}")
+
+    # Create a supervised tool
+    supervised_tool = SupervisedTool(
+        tool=tool,
+        supervisor=supervisor,
+        name=tool.name,
+        description=tool.description,
+        args_schema=tool.args_schema,
+        messages=[],
+    )
+
+    # The first call should be approved
+    print("First call (should be approved):")
+    result = supervised_tool.invoke({})
+    print(f"Result: {result}")
+
+    # The second call should be denied
+    print("\nSecond call (should be denied):")
+    result = supervised_tool.invoke({})
+    print(f"Result: {result}")
+
+    # The third call should be approved
+    print("\nThird call (should be approved):")
+    result = supervised_tool.invoke({})
+    print(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces a `SupervisedTool` example that demonstrates how to use a supervisor to approve or deny tool calls.

The following changes are included:

- A `get_current_time` tool that returns the current time.
- A `SimpleSupervisor` that approves every other tool call.
- A `tool_example.py` script that demonstrates how to use the `SupervisedTool` with the `SimpleSupervisor`.