### PR TITLE
docs: Add 'Services' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
-# Talos
+# Talos: An AI Protocol Owner
 
-This repository contains the code for Talos, an AI agent for managing a cryptocurrency treasury, built with LangChain. The official documentation for the Talos project can be found at [docs.talos.is](https://docs.talos.is/).
+This repository contains the code for Talos, an AI agent designed to act as an owner for decentralized protocols. Talos is not just a chatbot; it is a sophisticated AI system that can manage and govern a protocol, ensuring its integrity and security.
 
-Used LangChain to create a conversational agent with both research and onchain transaction execution capabilities. The agent is designed to be used by a DAO to manage its treasury, and can be used to perform tasks such as:
+The official documentation for the Talos project can be found at [docs.talos.is](https://docs.talos.is/).
 
--   Researching and evaluating investment opportunities
--   Executing trades on decentralized exchanges
--   Providing reports on the treasury's performance
+## What is Talos?
 
-The agent is designed to be extensible, and can be customized to meet the specific needs of a DAO. For example, it can be configured to use different data sources, or to use different trading strategies. For more information on the governance and vault strategies, please see the [governance](https://docs.talos.is/governance) and [vault strategies](https://docs.talos.is/vault-strategies) pages on the official documentation.
+Talos is an AI agent that can:
+
+-   **Govern Protocol Actions:** Talos uses a Hypervisor to monitor and approve or deny actions taken by other agents or system components. This ensures that all actions align with the protocol's rules and objectives.
+-   **Evaluate Governance Proposals:** Talos can analyze and provide recommendations on governance proposals, considering their potential benefits, risks, and community feedback.
+-   **Interact with the Community:** Talos can engage with the community on platforms like Twitter to provide updates, answer questions, and gather feedback.
+-   **Manage its Own Codebase:** Talos can interact with GitHub to manage its own source code, including reviewing and committing changes.
+-   **Update Documentation:** Talos can update its own documentation on GitBook to ensure it remains accurate and up-to-date.
 
 ## Directory Structure
 
@@ -16,36 +20,30 @@ The repository is structured as follows:
 
 -   `.github/`: Contains GitHub Actions workflows for CI/CD.
 -   `src/`: Contains the source code for the Talos agent.
-    -   `crypto_sentiment/`: Contains a sub-package for sentiment analysis of cryptocurrencies.
     -   `talos/`: Contains the main source code for the Talos agent.
-        -   `agent/`: Contains the core agent logic.
         -   `core/`: Contains the core components of the agent, such as the CLI and the main agent loop.
-        -   `services/`: Contains the different services that the agent can perform, such as research and trading.
-        -   `hypervisor/`: Contains the hypervisor for managing the agent's services. The hypervisor is responsible for monitoring the agent's actions and ensuring that it doesn't do anything wrong. It will also be used to evaluate proposals, which are tracked at [https://github.com/talos-agent/TIPs](https://github.com/talos-agent/TIPs).
+        -   `hypervisor/`: Contains the Hypervisor and Supervisor components, which are responsible for overseeing the agent's actions.
+        -   `services/`: Contains the different services that the agent can perform, such as evaluating proposals.
         -   `prompts/`: Contains the prompts used by the agent.
         -   `tools/`: Contains the tools that the agent can use, such as GitBook, GitHub, IPFS, and Twitter.
-        -   `utils/`: Contains utility functions.
 -   `tests/`: Contains the tests for the Talos agent.
 -   `proposal_example.py`: An example of how to use the agent to evaluate a proposal.
 
 ## Key Components
 
-Talos is comprised of several key components that allow it to function as a decentralized AI agent. These components are:
+Talos is comprised of several key components that allow it to function as a decentralized AI protocol owner:
 
--   **Twitter:** Talos can interact with users on Twitter, allowing it to engage with the community and respond to inquiries.
--   **GitHub:** Talos can interact with GitHub, allowing it to review code, commit code, and manage its own codebase.
--   **GitBook:** Talos can interact with GitBook, allowing it to update its own documentation.
--   **Proposals:** Talos can manage its own treasury and key protocol actions through a proposal system.
--   **Hypervisor and Council:** The hypervisor and the council are responsible for protecting Talos from performing any nefarious actions.
+-   **Hypervisor and Supervisor:** The Hypervisor is the core of Talos's governance capabilities. It monitors all actions and uses a Supervisor to approve or deny them based on a set of rules and the agent's history. This protects the protocol from malicious or erroneous actions.
+-   **Proposal Evaluation System:** Talos can systematically evaluate governance proposals, providing a detailed analysis to help stakeholders make informed decisions.
+-   **Tool-Based Architecture:** Talos uses a variety of tools to interact with external services like Twitter, GitHub, and GitBook, allowing it to perform a wide range of tasks.
 
-## Tools
+## Services
 
-The project provides a set of tools for interacting with various services:
+Talos provides a set of services for interacting with various platforms:
 
--   `gitbook`: A tool for interacting with GitBook.
--   `github`: A tool for interacting with GitHub.
--   `ipfs`: A tool for interacting with IPFS.
--   `twitter`: A tool for interacting with Twitter.
+-   **Twitter:** Talos can use its Twitter service to post tweets, reply to mentions, and monitor conversations, allowing it to engage with the community and stay informed about the latest developments.
+-   **GitHub:** The GitHub service enables Talos to interact with repositories, manage issues, and review and commit code. This allows Talos to autonomously manage its own codebase and contribute to other projects.
+-   **GitBook:** With the GitBook service, Talos can create, edit, and manage documentation. This ensures that the project's documentation is always up-to-date.
 
 ## Development
 
@@ -95,11 +93,13 @@ You can then interact with the agent in a continuous conversation. To exit, type
 To run the proposal evaluation example, run the following command:
 
 ```bash
-export OPENAI_API_KEY="your-openai-api-key"
+export OPENAI_API_key="<OPENAI_API_KEY>"
 python proposal_example.py
 ```
 
 ## Testing
+
+To run the test suite, use the following command:
 
 ```bash
 pytest
@@ -107,7 +107,9 @@ pytest
 
 ## Linting and Type Checking
 
+To lint and type-check the code, run the following commands:
+
 ```bash
 ruff check .
-ty check .
+mypy .
 ```


### PR DESCRIPTION
This commit adds a new 'Services' section to the README.md file. This section provides details on the Twitter, GitHub, and GitBook services that I can use to interact with various platforms.