### PR TITLE
update install guide - pyproject.toml didn't have [core]

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This project uses `uv` for dependency management.
 4.  Install dependencies:
 
     ```bash
-    uv pip install -e .[core,dev]
+    uv pip install -e ".[dev]"
     ```
 
 ## Usage


### PR DESCRIPTION
the old install command was:

uv pip install -e .[core, dev]

pyproject.toml does not define core, just defines dev

line updated to be:

uv pip install -e ".[core, dev]"