### PR TITLE
I’ve prevented tests from leaving artifacts by modifying `tests/test_…

### DIFF
--- a/src/talos/tools/twitter_client.py
+++ b/src/talos/tools/twitter_client.py
@@ -9,8 +9,8 @@ from textblob import TextBlob
 
 class TwitterConfig(BaseSettings):
     TWITTER_BEARER_TOKEN: Optional[str] = None
-    
-    @model_validator(mode='after')
+
+    @model_validator(mode="after")
     def validate_bearer_token(self):
         if not self.TWITTER_BEARER_TOKEN:
             raise ValueError("TWITTER_BEARER_TOKEN environment variable is required but not set")
@@ -53,7 +53,7 @@ class TwitterClient(ABC):
 
 class TweepyClient(TwitterClient):
     client: tweepy.Client
-    
+
     def __init__(self):
         config = TwitterConfig()
         self.client = tweepy.Client(bearer_token=config.TWITTER_BEARER_TOKEN)

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -25,12 +25,15 @@ def test_main_agent_initialization(mock_model: BaseChatModel) -> None:
     with (
         patch("talos.core.main_agent.FilePromptManager") as mock_file_prompt_manager,
         patch("talos.core.main_agent.Hypervisor") as mock_hypervisor,
-        patch.dict("os.environ", {
-            "GITHUB_TOKEN": "test_token",
-            "GITHUB_API_TOKEN": "test_token", 
-            "OPENAI_API_KEY": "test_key",
-            "TWITTER_BEARER_TOKEN": "test_twitter_token",
-        }),
+        patch.dict(
+            "os.environ",
+            {
+                "GITHUB_TOKEN": "test_token",
+                "GITHUB_API_TOKEN": "test_token",
+                "OPENAI_API_KEY": "test_key",
+                "TWITTER_BEARER_TOKEN": "test_twitter_token",
+            },
+        ),
         patch("os.environ.get") as mock_os_get,
         patch("ssl.create_default_context", return_value=MagicMock()),
         patch("tweepy.Client"),

--- a/tests/test_memory_tool.py
+++ b/tests/test_memory_tool.py
@@ -1,3 +1,5 @@
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, create_autospec
@@ -42,21 +44,22 @@ class TestAddMemoryToolIntegration(unittest.TestCase):
         mock_model = create_autospec(BaseChatModel)
         mock_model.with_structured_output.return_value = create_autospec(Runnable)
 
+        # Create a temporary directory
+        self.temp_dir = tempfile.mkdtemp()
+
         # Create a mock agent
         self.agent = Agent(
             model=mock_model,
             memory=Memory(
-                file_path=Path("test_memory.json"),
+                file_path=Path(self.temp_dir) / "test_memory.json",
                 embeddings_model=MockEmbeddings(),
             ),
         )
         AddMemoryTool.model_rebuild()
 
     def tearDown(self) -> None:
-        if Path("test_memory.json").exists():
-            Path("test_memory.json").unlink()
-        if Path("test_memory.index").exists():
-            Path("test_memory.index").unlink()
+        # Remove the temporary directory
+        shutil.rmtree(self.temp_dir)
 
     def test_run_integration(self):
         # Get the tool from the agent's tool manager

--- a/tests/test_prompt_concatenation.py
+++ b/tests/test_prompt_concatenation.py
@@ -25,12 +25,15 @@ def test_prompt_concatenation(mock_model: BaseChatModel) -> None:
     with (
         patch("talos.core.main_agent.FilePromptManager") as mock_file_prompt_manager,
         patch("talos.core.main_agent.Hypervisor") as mock_hypervisor,
-        patch.dict("os.environ", {
-            "GITHUB_TOKEN": "test_token",
-            "GITHUB_API_TOKEN": "test_token",
-            "OPENAI_API_KEY": "test_key", 
-            "TWITTER_BEARER_TOKEN": "test_twitter_token",
-        }),
+        patch.dict(
+            "os.environ",
+            {
+                "GITHUB_TOKEN": "test_token",
+                "GITHUB_API_TOKEN": "test_token",
+                "OPENAI_API_KEY": "test_key",
+                "TWITTER_BEARER_TOKEN": "test_twitter_token",
+            },
+        ),
         patch("os.environ.get") as mock_os_get,
         patch("ssl.create_default_context", return_value=MagicMock()),
         patch("tweepy.Client"),


### PR DESCRIPTION
…memory_tool.py` to use a temporary directory for the memory files.