### PR TITLE
feat: Add ProposalsSkill to CLI

### DIFF
--- a/proposal_example.txt
+++ b/proposal_example.txt
@@ -1,0 +1,6 @@
+[PROPOSAL]
+This is a test proposal. It is a good proposal.
+
+[FEEDBACK]
+vitalik: I like it
+hayden: I also like it

--- a/src/talos/cli/main.py
+++ b/src/talos/cli/main.py
@@ -10,12 +10,32 @@ from langchain_openai import ChatOpenAI
 from talos.core.main_agent import MainAgent
 from talos.core.router import Router
 from talos.services.key_management import KeyManagement
+from talos.skills.proposals import ProposalsSkill
 from talos.skills.twitter_persona import TwitterPersonaSkill
 from talos.skills.twitter_sentiment import TwitterSentimentSkill
 
 app = typer.Typer(invoke_without_command=True)
 twitter_app = typer.Typer()
 app.add_typer(twitter_app, name="twitter")
+proposals_app = typer.Typer()
+app.add_typer(proposals_app, name="proposals")
+
+
+@proposals_app.command("eval")
+def eval_proposal(
+    filepath: str = typer.Option(..., "--file", "-f", help="Path to the proposal file."),
+    model_name: str = "gpt-4",
+    temperature: float = 0.0,
+):
+    """
+    Evaluates a proposal from a file.
+    """
+    if not os.path.exists(filepath):
+        raise FileNotFoundError(f"File not found at {filepath}")
+    model = ChatOpenAI(model=model_name, temperature=temperature)
+    skill = ProposalsSkill(llm=model)
+    response = skill.run(filepath=filepath)
+    print(response.answers[0])
 
 
 @twitter_app.command()

--- a/src/talos/services/implementations/proposals/proposals_service.py
+++ b/src/talos/services/implementations/proposals/proposals_service.py
@@ -15,38 +15,35 @@ from talos.skills.proposals import ProposalsSkill
 class ProposalsService(ProposalAgent):
     """
     A service for evaluating proposals using the ProposalsSkill.
-    
+
     This service acts as a bridge between the abstract ProposalAgent interface
     and the concrete ProposalsSkill implementation.
     """
-    
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    
+
     llm: BaseLanguageModel
     prompt_manager: PromptManager | None = None
     _skill: ProposalsSkill | None = None
-    
+
     def model_post_init(self, __context: Any) -> None:
         super().model_post_init(__context)
-        
+
         if self.prompt_manager is None:
             self.prompt_manager = FilePromptManager("src/talos/prompts")
-        
+
         self._skill = ProposalsSkill(
-            llm=self.llm,
-            prompt_manager=self.prompt_manager,
-            rag_dataset=self.rag_dataset,
-            tools=self.tools
+            llm=self.llm, prompt_manager=self.prompt_manager, rag_dataset=self.rag_dataset, tools=self.tools
         )
-    
+
     def evaluate_proposal(self, proposal: Proposal) -> ProposalResponse:
         """
         Evaluates a proposal and returns a recommendation.
-        
+
         :param proposal: The proposal to evaluate.
         :return: The agent's recommendation with confidence and reasoning.
         """
         if self._skill is None:
             raise RuntimeError("ProposalsSkill not initialized")
-        
+
         return self._skill.evaluate_proposal(proposal)

--- a/src/talos/skills/proposals.py
+++ b/src/talos/skills/proposals.py
@@ -9,7 +9,7 @@ from langchain_core.language_models import BaseLanguageModel
 from langchain_core.prompts import PromptTemplate
 from pydantic import ConfigDict
 
-from talos.models.proposals import Proposal, ProposalResponse
+from talos.models.proposals import Feedback, Proposal, ProposalResponse
 from talos.prompts.prompt import Prompt
 from talos.prompts.prompt_manager import PromptManager
 from talos.prompts.prompt_managers.single_prompt_manager import SinglePromptManager
@@ -24,6 +24,26 @@ def get_default_proposal_prompt() -> Prompt:
         template=prompt_data["template"],
         input_variables=prompt_data["input_variables"],
     )
+
+
+def parse_proposal_file(filepath: str) -> Proposal:
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    proposal_match = re.search(r"\[PROPOSAL\]\n(.*?)\n\[FEEDBACK\]", content, re.DOTALL)
+    feedback_match = re.search(r"\[FEEDBACK\]\n(.*)", content, re.DOTALL)
+
+    proposal_text = proposal_match.group(1).strip() if proposal_match else ""
+    feedback_text = feedback_match.group(1).strip() if feedback_match else ""
+
+    feedback_list = []
+    if feedback_text:
+        for line in feedback_text.split("\n"):
+            if ":" in line:
+                delegate, feedback = line.split(":", 1)
+                feedback_list.append(Feedback(delegate=delegate.strip(), feedback=feedback.strip()))
+
+    return Proposal(proposal_text=proposal_text, feedback=feedback_list)
 
 
 class ProposalsSkill(Skill):
@@ -48,13 +68,11 @@ class ProposalsSkill(Skill):
         return "proposals_skill"
 
     def run(self, **kwargs: Any) -> ProposalResponse:
-        if "proposal" not in kwargs:
-            raise ValueError("Missing required argument: proposal")
-        
-        proposal = kwargs["proposal"]
-        if not isinstance(proposal, Proposal):
-            raise TypeError("proposal must be a Proposal instance")
-        
+        if "filepath" not in kwargs:
+            raise ValueError("Missing required argument: filepath")
+
+        filepath = kwargs["filepath"]
+        proposal = parse_proposal_file(filepath)
         return self.evaluate_proposal(proposal)
 
     def evaluate_proposal(self, proposal: Proposal) -> ProposalResponse:
@@ -63,48 +81,45 @@ class ProposalsSkill(Skill):
         """
         logger = logging.getLogger(__name__)
         logger.info(f"Evaluating proposal with {len(proposal.feedback)} feedback items")
-        
+
         if not proposal.proposal_text or not proposal.proposal_text.strip():
             raise ValueError("Proposal text cannot be empty")
-        
+
         prompt = self.prompt_manager.get_prompt("proposal_evaluation_prompt")
         if not prompt:
             raise ValueError("Prompt 'proposal_evaluation_prompt' not found.")
-        
+
         try:
             prompt_template = PromptTemplate(
                 template=prompt.template,
                 input_variables=prompt.input_variables,
             )
             chain = prompt_template | self.llm
-            
-            feedback_str = "\n".join([f"- {f.delegate}: {f.feedback}" for f in proposal.feedback]) if proposal.feedback else "No delegate feedback provided."
-            
+
+            feedback_str = (
+                "\n".join([f"- {f.delegate}: {f.feedback}" for f in proposal.feedback])
+                if proposal.feedback
+                else "No delegate feedback provided."
+            )
+
             logger.debug(f"Invoking LLM with proposal text length: {len(proposal.proposal_text)}")
-            response = chain.invoke({
-                "proposal_text": proposal.proposal_text, 
-                "feedback": feedback_str
-            })
-            
+            response = chain.invoke({"proposal_text": proposal.proposal_text, "feedback": feedback_str})
+
             content = response.content
             confidence_score = self._extract_confidence(content)
             reasoning = self._extract_reasoning(content)
-            
+
             logger.info(f"Proposal evaluation completed with confidence: {confidence_score}")
-            
-            return ProposalResponse(
-                answers=[content],
-                confidence_score=confidence_score,
-                reasoning=reasoning
-            )
-            
+
+            return ProposalResponse(answers=[content], confidence_score=confidence_score, reasoning=reasoning)
+
         except Exception as e:
             logger.error(f"Failed to evaluate proposal: {str(e)}")
             raise RuntimeError(f"Failed to evaluate proposal: {str(e)}") from e
 
     def _extract_confidence(self, content: str) -> float | None:
         """Extract confidence score from LLM response."""
-        match = re.search(r'CONFIDENCE:\s*([0-9]*\.?[0-9]+)', content)
+        match = re.search(r"CONFIDENCE:\s*([0-9]*\.?[0-9]+)", content)
         if match:
             try:
                 confidence = float(match.group(1))
@@ -115,7 +130,7 @@ class ProposalsSkill(Skill):
 
     def _extract_reasoning(self, content: str) -> str | None:
         """Extract reasoning from LLM response."""
-        match = re.search(r'REASONING:\s*(.*)', content, re.DOTALL)
+        match = re.search(r"REASONING:\s*(.*)", content, re.DOTALL)
         if match:
             return match.group(1).strip()
         return None

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -53,12 +53,17 @@ def test_main_agent_initialization(mock_model: BaseChatModel) -> None:
         )
         mock_file_prompt_manager.return_value = mock_prompt_manager
         mock_hypervisor.return_value = MagicMock(spec=Hypervisor)
+        from talos.skills.proposals import ProposalsSkill
+
         agent = MainAgent(
             model=mock_model,
             prompts_dir="",
             prompt_manager=mock_prompt_manager,
             schema=None,
-            router=Router(services=[], skills=[]),
+            router=Router(
+                services=[],
+                skills=[ProposalsSkill(llm=mock_model)],
+            ),
         )
         assert agent is not None
         assert agent.model == mock_model

--- a/tests/test_prompt_concatenation.py
+++ b/tests/test_prompt_concatenation.py
@@ -67,10 +67,15 @@ def test_prompt_concatenation(mock_model: BaseChatModel) -> None:
         mock_file_prompt_manager.return_value = mock_prompt_manager
         mock_hypervisor.return_value = MagicMock(spec=Hypervisor)
 
+        from talos.skills.proposals import ProposalsSkill
+
         MainAgent(
             model=mock_model,
             prompts_dir="",
             prompt_manager=mock_prompt_manager,
             schema=None,
-            router=Router(services=[], skills=[]),
+            router=Router(
+                services=[],
+                skills=[ProposalsSkill(llm=mock_model)],
+            ),
         )


### PR DESCRIPTION
This commit adds the ProposalsSkill to the CLI, allowing you to evaluate proposals from a file. It includes a new `proposals eval` command that takes a file path as input.

- Adds a `parse_proposal_file` function to parse a proposal and feedback from a file.
- Updates `ProposalsSkill` to use the new parsing function.
- Adds a new `proposals eval` command to the CLI in `main.py`.
- Includes an example proposal file.