### PR TITLE
github repo caching

### DIFF
--- a/PERFORMANCE_ANALYSIS.md
+++ b/PERFORMANCE_ANALYSIS.md
@@ -129,6 +129,14 @@ for skill in self.router.skills:
 - Added destructor to ensure data persistence
 - Maintains backward compatibility
 
+✅ **GitHub API Repository Caching**: Implemented TTL-based repository caching
+- Added `TTLCache` with configurable cache size (default: 20) and TTL (default: 5 minutes)
+- Created `_get_cached_repo()` method to handle cache logic
+- Updated all 15+ methods to use cached repository objects instead of repeated API calls
+- Added cache management methods: `get_cache_info()` and `clear_cache()`
+- Comprehensive test coverage for cache behavior including TTL expiration and LRU eviction
+- Maintains full backward compatibility with existing API
+
 ## Recommendations
 
 1. Monitor memory usage patterns to optimize batch sizes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dev = [
     "mypy==1.17.0",
     "pytest==8.4.1",
     "pytest-mock==3.14.1",
-    "isort==5.12.0"
+    "isort==5.12.0",
+    "types-cachetools",
 ]
 
 [tool.ruff]

--- a/src/talos/tools/github/tools.py
+++ b/src/talos/tools/github/tools.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import requests
+from cachetools import TTLCache
 from github import Auth, Github
 from pydantic import BaseModel, Field, PrivateAttr
 
@@ -13,20 +14,63 @@ class GithubTools(BaseModel):
     """
 
     token: str | None = Field(default_factory=lambda: GitHubSettings().GITHUB_API_TOKEN)
+    cache_ttl: int = Field(default=300, description="Repository cache TTL in seconds (default: 5 minutes)")
+    cache_maxsize: int = Field(default=20, description="Maximum number of repositories to cache")
     _github: Github = PrivateAttr()
     _headers: dict[str, str] = PrivateAttr()
+    _repo_cache: TTLCache = PrivateAttr()
 
     def model_post_init(self, __context: Any) -> None:
         if not self.token:
             raise ValueError("Github token not provided.")
         self._github = Github(auth=Auth.Token(self.token))
         self._headers = {"Authorization": f"token {self.token}"}
+        self._repo_cache = TTLCache(maxsize=self.cache_maxsize, ttl=self.cache_ttl)
+
+    def _get_cached_repo(self, user: str, project: str):
+        """
+        Get a repository object with caching to reduce API calls.
+
+        Args:
+            user: GitHub username or organization
+            project: Repository name
+
+        Returns:
+            Repository object from cache or fresh from API
+        """
+        cache_key = f"{user}/{project}"
+
+        if cache_key in self._repo_cache:
+            return self._repo_cache[cache_key]
+
+        # Cache miss - fetch from API and store
+        repo = self._github.get_repo(cache_key)
+        self._repo_cache[cache_key] = repo
+        return repo
+
+    def get_cache_info(self) -> dict[str, Any]:
+        """
+        Get information about the current cache state.
+
+        Returns:
+            Dictionary with cache statistics
+        """
+        return {
+            "cache_size": len(self._repo_cache),
+            "max_size": self._repo_cache.maxsize,
+            "ttl": self._repo_cache.ttl,
+            "cached_repos": list(self._repo_cache.keys()),
+        }
+
+    def clear_cache(self) -> None:
+        """Clear the repository cache."""
+        self._repo_cache.clear()
 
     def get_open_issues(self, user: str, project: str) -> list[dict[str, Any]]:
         """
         Gets all open issues for a given repository.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         return [
             {"number": issue.number, "title": issue.title, "url": issue.html_url}
             for issue in repo.get_issues(state="open")
@@ -38,14 +82,14 @@ class GithubTools(BaseModel):
 
         :param state: Can be one of 'open', 'closed', or 'all'.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         return [{"number": pr.number, "title": pr.title, "url": pr.html_url} for pr in repo.get_pulls(state=state)]
 
     def get_issue_comments(self, user: str, project: str, issue_number: int) -> list[dict[str, Any]]:
         """
         Gets all comments for a given issue.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         issue = repo.get_issue(number=issue_number)
         comments = []
         for comment in issue.get_comments():
@@ -62,7 +106,7 @@ class GithubTools(BaseModel):
         """
         Gets all comments for a given pull request.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         pr = repo.get_pull(pr_number)
         comments = []
         for comment in pr.get_issue_comments():
@@ -78,7 +122,7 @@ class GithubTools(BaseModel):
         """
         Replies to a given issue.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         issue = repo.get_issue(number=issue_number)
         issue.create_comment(comment)
 
@@ -86,7 +130,7 @@ class GithubTools(BaseModel):
         """
         Gets all files for a given pull request.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         pr = repo.get_pull(number=pr_number)
         return [file.filename for file in pr.get_files()]
 
@@ -94,7 +138,7 @@ class GithubTools(BaseModel):
         """
         Gets the diff for a given pull request.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         pr = repo.get_pull(number=pr_number)
         response = requests.get(pr.patch_url, headers=self._headers)
         response.raise_for_status()
@@ -104,7 +148,7 @@ class GithubTools(BaseModel):
         """
         Gets the project structure for a given repository.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         contents = repo.get_contents(path)
         if isinstance(contents, list):
             return [content.path for content in contents]
@@ -114,7 +158,7 @@ class GithubTools(BaseModel):
         """
         Gets the content of a file.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         content = repo.get_contents(filepath)
         if isinstance(content, list):
             raise ValueError("Path is a directory, not a file.")
@@ -124,7 +168,7 @@ class GithubTools(BaseModel):
         """
         Merges a pull request.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         pr = repo.get_pull(number=pr_number)
         pr.merge()
 
@@ -132,7 +176,7 @@ class GithubTools(BaseModel):
         """
         Reviews a pull request.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         pr = repo.get_pull(number=pr_number)
         pr.create_review(body=feedback, event="COMMENT")
 
@@ -140,7 +184,7 @@ class GithubTools(BaseModel):
         """
         Comments on a pull request.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         pr = repo.get_pull(number=pr_number)
         pr.create_issue_comment(comment)
 
@@ -148,7 +192,7 @@ class GithubTools(BaseModel):
         """
         Approves a pull request.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         pr = repo.get_pull(number=pr_number)
         pr.create_review(event="APPROVE")
 
@@ -156,6 +200,6 @@ class GithubTools(BaseModel):
         """
         Creates a new issue.
         """
-        repo = self._github.get_repo(f"{user}/{project}")
+        repo = self._get_cached_repo(user, project)
         issue = repo.create_issue(title=title, body=body)
         return {"number": issue.number, "title": issue.title, "url": issue.html_url}

--- a/tests/test_github_tools.py
+++ b/tests/test_github_tools.py
@@ -13,14 +13,119 @@ class TestGithubTools(unittest.TestCase):
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
             self.github_tools = GithubTools()
 
+    # Original GitHub functionality tests
+    @patch("talos.tools.github.tools.Github")
+    def test_create_issue(self, mock_github: MagicMock) -> None:
+        # Arrange
+        mock_github_instance = mock_github.return_value
+        mock_repo = MagicMock()
+        mock_issue = MagicMock()
+        mock_issue.number = 123
+        mock_issue.title = "Test Issue"
+        mock_issue.html_url = "http://example.com/issue/123"
+        mock_repo.create_issue.return_value = mock_issue
+        mock_github_instance.get_repo.return_value = mock_repo
+
+        tools = GithubTools(token="test_token")
+
+        # Act
+        result = tools.create_issue(
+            user="test_user",
+            project="test_repo",
+            title="Test Issue",
+            body="This is a test issue.",
+        )
+
+        # Assert
+        self.assertEqual(
+            result,
+            {
+                "number": 123,
+                "title": "Test Issue",
+                "url": "http://example.com/issue/123",
+            },
+        )
+        mock_github_instance.get_repo.assert_called_once_with("test_user/test_repo")
+        mock_repo.create_issue.assert_called_once_with(title="Test Issue", body="This is a test issue.")
+
+    @patch("talos.tools.github.tools.Github")
+    def test_get_all_pull_requests(self, mock_github: MagicMock) -> None:
+        # Arrange
+        mock_github_instance = mock_github.return_value
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_pr.number = 1
+        mock_pr.title = "Test PR"
+        mock_pr.html_url = "http://example.com/pr/1"
+        mock_repo.get_pulls.return_value = [mock_pr]
+        mock_github_instance.get_repo.return_value = mock_repo
+
+        tools = GithubTools(token="test_token")
+
+        # Act
+        result = tools.get_all_pull_requests(user="test_user", project="test_repo", state="all")
+
+        # Assert
+        self.assertEqual(
+            result,
+            [
+                {
+                    "number": 1,
+                    "title": "Test PR",
+                    "url": "http://example.com/pr/1",
+                }
+            ],
+        )
+        mock_github_instance.get_repo.assert_called_once_with("test_user/test_repo")
+        mock_repo.get_pulls.assert_called_once_with(state="all")
+
+    @patch("talos.tools.github.tools.Github")
+    def test_comment_on_pr(self, mock_github: MagicMock) -> None:
+        # Arrange
+        mock_github_instance = mock_github.return_value
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+        mock_github_instance.get_repo.return_value = mock_repo
+
+        tools = GithubTools(token="test_token")
+
+        # Act
+        tools.comment_on_pr(user="test_user", project="test_repo", pr_number=1, comment="Test comment")
+
+        # Assert
+        mock_github_instance.get_repo.assert_called_once_with("test_user/test_repo")
+        mock_repo.get_pull.assert_called_once_with(number=1)
+        mock_pr.create_issue_comment.assert_called_once_with("Test comment")
+
+    @patch("talos.tools.github.tools.Github")
+    def test_approve_pr(self, mock_github: MagicMock) -> None:
+        # Arrange
+        mock_github_instance = mock_github.return_value
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+        mock_github_instance.get_repo.return_value = mock_repo
+
+        tools = GithubTools(token="test_token")
+
+        # Act
+        tools.approve_pr(user="test_user", project="test_repo", pr_number=1)
+
+        # Assert
+        mock_github_instance.get_repo.assert_called_once_with("test_user/test_repo")
+        mock_repo.get_pull.assert_called_once_with(number=1)
+        mock_pr.create_review.assert_called_once_with(event="APPROVE")
+
+    # Repository caching tests
     @patch("talos.tools.github.tools.Github")
     def test_initialization_with_cache(self, mock_github_class):
         """Test that GithubTools initializes with proper cache configuration."""
         with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
-            
+
             tools = GithubTools(cache_ttl=600, cache_maxsize=10)
-            
+
             # Verify cache is initialized with correct parameters
             self.assertEqual(tools._repo_cache.maxsize, 10)
             self.assertEqual(tools._repo_cache.ttl, 600)
@@ -33,18 +138,18 @@ class TestGithubTools(unittest.TestCase):
         mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
         mock_github_instance.get_repo.return_value = mock_repo
-        
+
         with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
             tools = GithubTools()
-            
+
             # First call should be a cache miss
             result = tools._get_cached_repo("testuser", "testrepo")
-            
+
             # Verify API was called
             mock_github_instance.get_repo.assert_called_once_with("testuser/testrepo")
             self.assertEqual(result, mock_repo)
-            
+
             # Verify repo is now cached
             self.assertEqual(len(tools._repo_cache), 1)
             self.assertIn("testuser/testrepo", tools._repo_cache)
@@ -56,20 +161,20 @@ class TestGithubTools(unittest.TestCase):
         mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
         mock_github_instance.get_repo.return_value = mock_repo
-        
+
         with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
             tools = GithubTools()
-            
+
             # First call - cache miss
             result1 = tools._get_cached_repo("testuser", "testrepo")
-            
+
             # Second call - should be cache hit
             result2 = tools._get_cached_repo("testuser", "testrepo")
-            
+
             # Verify API was only called once
             mock_github_instance.get_repo.assert_called_once_with("testuser/testrepo")
-            
+
             # Both results should be the same object
             self.assertEqual(result1, result2)
             self.assertEqual(result1, mock_repo)
@@ -81,19 +186,19 @@ class TestGithubTools(unittest.TestCase):
         mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
         mock_github_instance.get_repo.return_value = mock_repo
-        
+
         with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
             # Use very short TTL for testing
             tools = GithubTools(cache_ttl=1)
-            
+
             # First call
             tools._get_cached_repo("testuser", "testrepo")
             self.assertEqual(mock_github_instance.get_repo.call_count, 1)
-            
+
             # Wait for TTL to expire
             time.sleep(1.1)
-            
+
             # Second call after expiration - should hit API again
             tools._get_cached_repo("testuser", "testrepo")
             self.assertEqual(mock_github_instance.get_repo.call_count, 2)
@@ -105,25 +210,20 @@ class TestGithubTools(unittest.TestCase):
         mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
         mock_github_instance.get_repo.return_value = mock_repo
-        
+
         with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
             tools = GithubTools(cache_ttl=300, cache_maxsize=20)
-            
+
             # Initially empty cache
             info = tools.get_cache_info()
-            expected = {
-                "cache_size": 0,
-                "max_size": 20,
-                "ttl": 300,
-                "cached_repos": []
-            }
+            expected = {"cache_size": 0, "max_size": 20, "ttl": 300, "cached_repos": []}
             self.assertEqual(info, expected)
-            
+
             # Add some repos to cache
             tools._get_cached_repo("user1", "repo1")
             tools._get_cached_repo("user2", "repo2")
-            
+
             info = tools.get_cache_info()
             self.assertEqual(info["cache_size"], 2)
             self.assertEqual(info["max_size"], 20)
@@ -138,20 +238,20 @@ class TestGithubTools(unittest.TestCase):
         mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
         mock_github_instance.get_repo.return_value = mock_repo
-        
+
         with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
             tools = GithubTools()
-            
+
             # Add repos to cache
             tools._get_cached_repo("user1", "repo1")
             tools._get_cached_repo("user2", "repo2")
             self.assertEqual(len(tools._repo_cache), 2)
-            
+
             # Clear cache
             tools.clear_cache()
             self.assertEqual(len(tools._repo_cache), 0)
-            
+
             # Verify next access hits API again
             mock_github_instance.get_repo.reset_mock()
             tools._get_cached_repo("user1", "repo1")
@@ -169,18 +269,18 @@ class TestGithubTools(unittest.TestCase):
         mock_issue.html_url = "https://github.com/test/test/issues/123"
         mock_repo.get_issues.return_value = [mock_issue]
         mock_github_instance.get_repo.return_value = mock_repo
-        
+
         with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
             tools = GithubTools()
-            
+
             # Call get_open_issues twice
             result1 = tools.get_open_issues("testuser", "testrepo")
             result2 = tools.get_open_issues("testuser", "testrepo")
-            
+
             # Verify API was only called once (second call used cache)
             mock_github_instance.get_repo.assert_called_once_with("testuser/testrepo")
-            
+
             # Verify results are correct
             expected = [{"number": 123, "title": "Test Issue", "url": "https://github.com/test/test/issues/123"}]
             self.assertEqual(result1, expected)
@@ -192,33 +292,33 @@ class TestGithubTools(unittest.TestCase):
         mock_github_instance = MagicMock()
         mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
-        
+
         # Mock different method responses
         mock_issue = MagicMock()
         mock_issue.number = 123
         mock_issue.title = "Test Issue"
         mock_issue.html_url = "https://github.com/test/test/issues/123"
         mock_repo.get_issues.return_value = [mock_issue]
-        
+
         mock_pr = MagicMock()
         mock_pr.number = 456
         mock_pr.title = "Test PR"
         mock_pr.html_url = "https://github.com/test/test/pull/456"
         mock_repo.get_pulls.return_value = [mock_pr]
-        
+
         mock_github_instance.get_repo.return_value = mock_repo
-        
+
         with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
             tools = GithubTools()
-            
+
             # Call different methods that should use the same cached repo
             tools.get_open_issues("testuser", "testrepo")
             tools.get_all_pull_requests("testuser", "testrepo")
-            
+
             # Verify API was only called once
             mock_github_instance.get_repo.assert_called_once_with("testuser/testrepo")
-            
+
             # Verify both methods were called on the same repo object
             mock_repo.get_issues.assert_called_once()
             mock_repo.get_pulls.assert_called_once()
@@ -230,17 +330,17 @@ class TestGithubTools(unittest.TestCase):
         mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
         mock_github_instance.get_repo.return_value = mock_repo
-        
+
         with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
             mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
             # Set small cache size for testing
             tools = GithubTools(cache_maxsize=2)
-            
+
             # Add repos up to cache limit
             tools._get_cached_repo("user1", "repo1")
             tools._get_cached_repo("user2", "repo2")
             self.assertEqual(len(tools._repo_cache), 2)
-            
+
             # Adding third repo should evict one (LRU behavior)
             tools._get_cached_repo("user3", "repo3")
             self.assertEqual(len(tools._repo_cache), 2)

--- a/tests/test_github_tools.py
+++ b/tests/test_github_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -7,108 +8,243 @@ from talos.tools.github.tools import GithubTools
 
 
 class TestGithubTools(unittest.TestCase):
+    def setUp(self):
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            self.github_tools = GithubTools()
+
     @patch("talos.tools.github.tools.Github")
-    def test_create_issue(self, mock_github: MagicMock) -> None:
-        # Arrange
-        mock_github_instance = mock_github.return_value
+    def test_initialization_with_cache(self, mock_github_class):
+        """Test that GithubTools initializes with proper cache configuration."""
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            
+            tools = GithubTools(cache_ttl=600, cache_maxsize=10)
+            
+            # Verify cache is initialized with correct parameters
+            self.assertEqual(tools._repo_cache.maxsize, 10)
+            self.assertEqual(tools._repo_cache.ttl, 600)
+            self.assertEqual(len(tools._repo_cache), 0)
+
+    @patch("talos.tools.github.tools.Github")
+    def test_get_cached_repo_cache_miss(self, mock_github_class):
+        """Test cache miss scenario - first time accessing a repo."""
+        mock_github_instance = MagicMock()
+        mock_github_class.return_value = mock_github_instance
+        mock_repo = MagicMock()
+        mock_github_instance.get_repo.return_value = mock_repo
+        
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            tools = GithubTools()
+            
+            # First call should be a cache miss
+            result = tools._get_cached_repo("testuser", "testrepo")
+            
+            # Verify API was called
+            mock_github_instance.get_repo.assert_called_once_with("testuser/testrepo")
+            self.assertEqual(result, mock_repo)
+            
+            # Verify repo is now cached
+            self.assertEqual(len(tools._repo_cache), 1)
+            self.assertIn("testuser/testrepo", tools._repo_cache)
+
+    @patch("talos.tools.github.tools.Github")
+    def test_get_cached_repo_cache_hit(self, mock_github_class):
+        """Test cache hit scenario - repo already in cache."""
+        mock_github_instance = MagicMock()
+        mock_github_class.return_value = mock_github_instance
+        mock_repo = MagicMock()
+        mock_github_instance.get_repo.return_value = mock_repo
+        
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            tools = GithubTools()
+            
+            # First call - cache miss
+            result1 = tools._get_cached_repo("testuser", "testrepo")
+            
+            # Second call - should be cache hit
+            result2 = tools._get_cached_repo("testuser", "testrepo")
+            
+            # Verify API was only called once
+            mock_github_instance.get_repo.assert_called_once_with("testuser/testrepo")
+            
+            # Both results should be the same object
+            self.assertEqual(result1, result2)
+            self.assertEqual(result1, mock_repo)
+
+    @patch("talos.tools.github.tools.Github")
+    def test_cache_ttl_expiration(self, mock_github_class):
+        """Test that cache entries expire after TTL."""
+        mock_github_instance = MagicMock()
+        mock_github_class.return_value = mock_github_instance
+        mock_repo = MagicMock()
+        mock_github_instance.get_repo.return_value = mock_repo
+        
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            # Use very short TTL for testing
+            tools = GithubTools(cache_ttl=1)
+            
+            # First call
+            tools._get_cached_repo("testuser", "testrepo")
+            self.assertEqual(mock_github_instance.get_repo.call_count, 1)
+            
+            # Wait for TTL to expire
+            time.sleep(1.1)
+            
+            # Second call after expiration - should hit API again
+            tools._get_cached_repo("testuser", "testrepo")
+            self.assertEqual(mock_github_instance.get_repo.call_count, 2)
+
+    @patch("talos.tools.github.tools.Github")
+    def test_cache_info(self, mock_github_class):
+        """Test cache info method returns correct statistics."""
+        mock_github_instance = MagicMock()
+        mock_github_class.return_value = mock_github_instance
+        mock_repo = MagicMock()
+        mock_github_instance.get_repo.return_value = mock_repo
+        
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            tools = GithubTools(cache_ttl=300, cache_maxsize=20)
+            
+            # Initially empty cache
+            info = tools.get_cache_info()
+            expected = {
+                "cache_size": 0,
+                "max_size": 20,
+                "ttl": 300,
+                "cached_repos": []
+            }
+            self.assertEqual(info, expected)
+            
+            # Add some repos to cache
+            tools._get_cached_repo("user1", "repo1")
+            tools._get_cached_repo("user2", "repo2")
+            
+            info = tools.get_cache_info()
+            self.assertEqual(info["cache_size"], 2)
+            self.assertEqual(info["max_size"], 20)
+            self.assertEqual(info["ttl"], 300)
+            self.assertIn("user1/repo1", info["cached_repos"])
+            self.assertIn("user2/repo2", info["cached_repos"])
+
+    @patch("talos.tools.github.tools.Github")
+    def test_clear_cache(self, mock_github_class):
+        """Test that clear_cache empties the cache."""
+        mock_github_instance = MagicMock()
+        mock_github_class.return_value = mock_github_instance
+        mock_repo = MagicMock()
+        mock_github_instance.get_repo.return_value = mock_repo
+        
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            tools = GithubTools()
+            
+            # Add repos to cache
+            tools._get_cached_repo("user1", "repo1")
+            tools._get_cached_repo("user2", "repo2")
+            self.assertEqual(len(tools._repo_cache), 2)
+            
+            # Clear cache
+            tools.clear_cache()
+            self.assertEqual(len(tools._repo_cache), 0)
+            
+            # Verify next access hits API again
+            mock_github_instance.get_repo.reset_mock()
+            tools._get_cached_repo("user1", "repo1")
+            mock_github_instance.get_repo.assert_called_once_with("user1/repo1")
+
+    @patch("talos.tools.github.tools.Github")
+    def test_get_open_issues_uses_cache(self, mock_github_class):
+        """Test that get_open_issues uses the cached repo."""
+        mock_github_instance = MagicMock()
+        mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
         mock_issue = MagicMock()
         mock_issue.number = 123
         mock_issue.title = "Test Issue"
-        mock_issue.html_url = "http://example.com/issue/123"
-        mock_repo.create_issue.return_value = mock_issue
+        mock_issue.html_url = "https://github.com/test/test/issues/123"
+        mock_repo.get_issues.return_value = [mock_issue]
         mock_github_instance.get_repo.return_value = mock_repo
-
-        tools = GithubTools(token="test_token")
-
-        # Act
-        result = tools.create_issue(
-            user="test_user",
-            project="test_repo",
-            title="Test Issue",
-            body="This is a test issue.",
-        )
-
-        # Assert
-        self.assertEqual(
-            result,
-            {
-                "number": 123,
-                "title": "Test Issue",
-                "url": "http://example.com/issue/123",
-            },
-        )
-        mock_github_instance.get_repo.assert_called_once_with("test_user/test_repo")
-        mock_repo.create_issue.assert_called_once_with(title="Test Issue", body="This is a test issue.")
+        
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            tools = GithubTools()
+            
+            # Call get_open_issues twice
+            result1 = tools.get_open_issues("testuser", "testrepo")
+            result2 = tools.get_open_issues("testuser", "testrepo")
+            
+            # Verify API was only called once (second call used cache)
+            mock_github_instance.get_repo.assert_called_once_with("testuser/testrepo")
+            
+            # Verify results are correct
+            expected = [{"number": 123, "title": "Test Issue", "url": "https://github.com/test/test/issues/123"}]
+            self.assertEqual(result1, expected)
+            self.assertEqual(result2, expected)
 
     @patch("talos.tools.github.tools.Github")
-    def test_get_all_pull_requests(self, mock_github: MagicMock) -> None:
-        # Arrange
-        mock_github_instance = mock_github.return_value
+    def test_multiple_methods_use_same_cached_repo(self, mock_github_class):
+        """Test that multiple methods can use the same cached repository."""
+        mock_github_instance = MagicMock()
+        mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
+        
+        # Mock different method responses
+        mock_issue = MagicMock()
+        mock_issue.number = 123
+        mock_issue.title = "Test Issue"
+        mock_issue.html_url = "https://github.com/test/test/issues/123"
+        mock_repo.get_issues.return_value = [mock_issue]
+        
         mock_pr = MagicMock()
-        mock_pr.number = 1
+        mock_pr.number = 456
         mock_pr.title = "Test PR"
-        mock_pr.html_url = "http://example.com/pr/1"
+        mock_pr.html_url = "https://github.com/test/test/pull/456"
         mock_repo.get_pulls.return_value = [mock_pr]
+        
         mock_github_instance.get_repo.return_value = mock_repo
-
-        tools = GithubTools(token="test_token")
-
-        # Act
-        result = tools.get_all_pull_requests(user="test_user", project="test_repo", state="all")
-
-        # Assert
-        self.assertEqual(
-            result,
-            [
-                {
-                    "number": 1,
-                    "title": "Test PR",
-                    "url": "http://example.com/pr/1",
-                }
-            ],
-        )
-        mock_github_instance.get_repo.assert_called_once_with("test_user/test_repo")
-        mock_repo.get_pulls.assert_called_once_with(state="all")
+        
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            tools = GithubTools()
+            
+            # Call different methods that should use the same cached repo
+            tools.get_open_issues("testuser", "testrepo")
+            tools.get_all_pull_requests("testuser", "testrepo")
+            
+            # Verify API was only called once
+            mock_github_instance.get_repo.assert_called_once_with("testuser/testrepo")
+            
+            # Verify both methods were called on the same repo object
+            mock_repo.get_issues.assert_called_once()
+            mock_repo.get_pulls.assert_called_once()
 
     @patch("talos.tools.github.tools.Github")
-    def test_comment_on_pr(self, mock_github: MagicMock) -> None:
-        # Arrange
-        mock_github_instance = mock_github.return_value
+    def test_cache_maxsize_limit(self, mock_github_class):
+        """Test that cache respects maxsize limit."""
+        mock_github_instance = MagicMock()
+        mock_github_class.return_value = mock_github_instance
         mock_repo = MagicMock()
-        mock_pr = MagicMock()
-        mock_repo.get_pull.return_value = mock_pr
         mock_github_instance.get_repo.return_value = mock_repo
-
-        tools = GithubTools(token="test_token")
-
-        # Act
-        tools.comment_on_pr(user="test_user", project="test_repo", pr_number=1, comment="Test comment")
-
-        # Assert
-        mock_github_instance.get_repo.assert_called_once_with("test_user/test_repo")
-        mock_repo.get_pull.assert_called_once_with(number=1)
-        mock_pr.create_issue_comment.assert_called_once_with("Test comment")
-
-    @patch("talos.tools.github.tools.Github")
-    def test_approve_pr(self, mock_github: MagicMock) -> None:
-        # Arrange
-        mock_github_instance = mock_github.return_value
-        mock_repo = MagicMock()
-        mock_pr = MagicMock()
-        mock_repo.get_pull.return_value = mock_pr
-        mock_github_instance.get_repo.return_value = mock_repo
-
-        tools = GithubTools(token="test_token")
-
-        # Act
-        tools.approve_pr(user="test_user", project="test_repo", pr_number=1)
-
-        # Assert
-        mock_github_instance.get_repo.assert_called_once_with("test_user/test_repo")
-        mock_repo.get_pull.assert_called_once_with(number=1)
-        mock_pr.create_review.assert_called_once_with(event="APPROVE")
+        
+        with patch("talos.tools.github.tools.GitHubSettings") as mock_settings:
+            mock_settings.return_value.GITHUB_API_TOKEN = "test_token"
+            # Set small cache size for testing
+            tools = GithubTools(cache_maxsize=2)
+            
+            # Add repos up to cache limit
+            tools._get_cached_repo("user1", "repo1")
+            tools._get_cached_repo("user2", "repo2")
+            self.assertEqual(len(tools._repo_cache), 2)
+            
+            # Adding third repo should evict one (LRU behavior)
+            tools._get_cached_repo("user3", "repo3")
+            self.assertEqual(len(tools._repo_cache), 2)
+            self.assertIn("user3/repo3", tools._repo_cache)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
in [`PERFORMANCE_ANALYSIS.md`](PERFORMANCE_ANALYSIS.md) there was the following medium impact issue:

****Issue**: Repository objects are fetched repeatedly instead of being cached.**

with the suggested/requested solution:

****Solution**: Implement repository object caching with TTL expiration.**

------------------------------------------------------------------------------------------------
**problem + solution:**
- the github api was being called in for the same repo in a short time period.
- each method in GithubTools was making new get_repo() calls even when accessing this same repo
- implemented caching using TTLCache with:
  - 5 min TTL. this can be adjusted, currently @ 300 seconds
  - LRU eviction with 20 repos. this can be changed as talos interacts with more repos 
<br>

**this should**
- lower latency + API calls

added new tests for github tools to cover cache testing
<br>
**file changes:**

PERFORMANCE_ANALYSIS.md
  - added what was done to increase performance when using github tools when it relates to cache and repos


pyproject.toml
  - added "types-cachetools' for mypy type checking


src/talos/tools/github/tools.py
  - added '_get_cached_repo' + 'get_cache_info' + 'clear_cache' methods
  - updated existing methods to include cached features


tests/test_github_tools.py
  - added tests for cache functions (9 inc. hits, misses, ttl expiration, lru eviction)
  -  kept original github tools tests